### PR TITLE
Fixes #9 - unify errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ async function authorize(options) {
   !metaScopes || metaScopes.length === 0 ? errors.push('metaScopes') : '';
   if (errors.length > 0) {
     return Promise.reject(
-      `Required parameter(s) ${errors.join(', ')} are missing`
+      new Error(`Required parameter(s) ${errors.join(', ')} are missing`)
     );
   }
 
@@ -82,8 +82,13 @@ async function authorize(options) {
   return fetch(`${ims}/ims/exchange/jwt/`, postOptions)
     .then(res => res.json())
     .then(json => {
-      if (!json.access_token) {
-        return Promise.reject(json);
+      const { access_token, error, error_description } = json;
+      if (!access_token) {
+        if (error && error_description) {
+          return Promise.reject(new Error(`${error}: ${error_description}`));
+        } else {
+          return Promise.reject(new Error(`An unknown error occurred while swapping jwt. The response is as follows: ${JSON.stringify(json)}`));
+        }        
       }
       return json;
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "jwtauth",
-  "version": "0.0.1",
+  "name": "@adobe/jwt-auth",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1354,7 +1354,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1375,12 +1376,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1395,17 +1398,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1522,7 +1528,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1534,6 +1541,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1548,6 +1556,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1555,12 +1564,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1579,6 +1590,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1659,7 +1671,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1671,6 +1684,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1756,7 +1770,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1792,6 +1807,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1811,6 +1827,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1854,12 +1871,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -238,24 +238,6 @@
         "normalize-path": "^2.1.1"
       }
     },
-    "append-transform": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
-      "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
-      "dev": true,
-      "requires": {
-        "default-require-extensions": "^2.0.0"
-      }
-    },
-    "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -318,15 +300,6 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
-    },
-    "async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.11"
-      }
     },
     "async-limiter": {
       "version": "1.0.0",
@@ -705,19 +678,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-      "dev": true,
-      "optional": true
-    },
-    "compare-versions": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
-      "integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg==",
-      "dev": true
-    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -838,15 +798,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
-    },
-    "default-require-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
-      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
-      "dev": true,
-      "requires": {
-        "strip-bom": "^3.0.0"
-      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -1018,12 +969,6 @@
           "optional": true
         }
       }
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
     },
     "estraverse": {
       "version": "4.2.0",
@@ -1253,16 +1198,6 @@
       "dev": true,
       "requires": {
         "bser": "^2.0.0"
-      }
-    },
-    "fileset": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
-      "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.3",
-        "minimatch": "^3.0.3"
       }
     },
     "fill-range": {
@@ -1950,26 +1885,6 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
-    "handlebars": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
-      "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
-      "dev": true,
-      "requires": {
-        "async": "^2.5.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -2328,20 +2243,12 @@
     },
     "istanbul-api": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.1.tgz",
-      "integrity": "sha512-kVmYrehiwyeBAk/wE71tW6emzLiHGjYIiDrc8sfyty4F8M02/lrgXSm+R1kXysmF20zArvmZXjlE/mg24TVPJw==",
+      "resolved": "",
       "dev": true,
       "requires": {
-        "async": "^2.6.1",
-        "compare-versions": "^3.2.1",
-        "fileset": "^2.0.3",
         "istanbul-lib-coverage": "^2.0.3",
-        "istanbul-lib-hook": "^2.0.3",
         "istanbul-lib-instrument": "^3.1.0",
-        "istanbul-lib-report": "^2.0.4",
         "istanbul-lib-source-maps": "^3.0.2",
-        "istanbul-reports": "^2.1.1",
-        "js-yaml": "^3.12.0",
         "make-dir": "^1.3.0",
         "minimatch": "^3.0.4",
         "once": "^1.4.0"
@@ -2352,15 +2259,6 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
       "integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
       "dev": true
-    },
-    "istanbul-lib-hook": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
-      "integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
-      "dev": true,
-      "requires": {
-        "append-transform": "^1.0.0"
-      }
     },
     "istanbul-lib-instrument": {
       "version": "3.1.0",
@@ -2375,28 +2273,6 @@
         "@babel/types": "^7.0.0",
         "istanbul-lib-coverage": "^2.0.3",
         "semver": "^5.5.0"
-      }
-    },
-    "istanbul-lib-report": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
-      "integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
-      "dev": true,
-      "requires": {
-        "istanbul-lib-coverage": "^2.0.3",
-        "make-dir": "^1.3.0",
-        "supports-color": "^6.0.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "istanbul-lib-source-maps": {
@@ -2418,15 +2294,6 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
-      }
-    },
-    "istanbul-reports": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
-      "integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
-      "dev": true,
-      "requires": {
-        "handlebars": "^4.1.0"
       }
     },
     "jest": {
@@ -2835,16 +2702,6 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
-    "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
-      "dev": true,
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      }
-    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -3217,12 +3074,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-      "dev": true
-    },
     "mixin-deep": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
@@ -3454,16 +3305,6 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
       }
     },
     "optionator": {
@@ -4247,12 +4088,6 @@
         "extend-shallow": "^3.0.0"
       }
     },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
-    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -4523,26 +4358,6 @@
         "prelude-ls": "~1.1.2"
       }
     },
-    "uglify-js": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "commander": "~2.17.1",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -4763,12 +4578,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "bugs": {
     "url": "https://github.com/adobe/jwt-auth/issues"
   },
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "scripts": {
     "test": "jest"
   },

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -1,3 +1,35 @@
+// MOCKS ////////////////////////////////////////////
+
+const mockAccessToken = 'asdasdasd'
+
+let jwt = require('jsonwebtoken')
+let jwtActual = require.requireActual('jsonwebtoken')
+jest.mock('jsonwebtoken', () => jest.fn())
+
+let mockResultSuccess = Promise.resolve({
+  ok: true,
+  json: () => Promise.resolve(
+    { access_token: mockAccessToken, expires_in: 123456 }
+  ) 
+})
+let mockResultFailure = Promise.resolve({
+  ok: false,
+  json: () => Promise.resolve(
+    { error: 'my_error_code', error_description: 'This is the error description.' }
+  ) 
+})
+let mockResultFailureUnknown = Promise.resolve({
+  ok: false,
+  json: () => Promise.resolve(
+    { foo: 'bar', baz: 'faz' }
+  ) 
+})
+
+let fetch = require('node-fetch')
+jest.mock('node-fetch', () => jest.fn())
+
+// ////////////////////////////////////////////
+
 const auth = require('../index');
 
 const clientId = '9x4f87e5xxxf46x68f68x46ee6ef2738';
@@ -10,19 +42,19 @@ const privateKey = 'aalsdjfajsldjfalsjkdfa;lsjf;aljs';
 describe('Validate input', () => {
   test('all parameters missing', () => {
     expect.assertions(1);
-    return expect(auth({})).rejects.toThrow();
+    return expect(auth({})).rejects.toThrow('Required parameter(s) clientId, technicalAccountId, orgId, clientSecret, privateKey, metaScopes are missing');
   });
   test('missing clientId', () => {
     expect.assertions(1);
     return expect(
       auth({ clientSecret, technicalAccountId, orgId, metaScopes, privateKey })
-    ).rejects.toThrow();
+    ).rejects.toThrow('Required parameter(s) clientId are missing');
   });
   test('missing clientSecret', () => {
     expect.assertions(1);
     return expect(
       auth({ clientId, technicalAccountId, orgId, metaScopes, privateKey })
-    ).rejects.toThrow();
+    ).rejects.toThrow('Required parameter(s) clientSecret are missing');
   });
   test('missing technicalAccountId', () => {
     expect.assertions(1);
@@ -34,7 +66,7 @@ describe('Validate input', () => {
         metaScopes,
         privateKey
       })
-    ).rejects.toThrow();
+    ).rejects.toThrow('Required parameter(s) technicalAccountId are missing');
   });
   test('missing orgId', () => {
     expect.assertions(1);
@@ -46,7 +78,7 @@ describe('Validate input', () => {
         metaScopes,
         privateKey
       })
-    ).rejects.toThrow();
+    ).rejects.toThrow('Required parameter(s) orgId are missing');
   });
   test('missing metaScopes', () => {
     expect.assertions(1);
@@ -58,7 +90,7 @@ describe('Validate input', () => {
         orgId,
         privateKey
       })
-    ).rejects.toThrow();
+    ).rejects.toThrow('Required parameter(s) metaScopes are missing');
   });
   test('missing privateKey', () => {
     expect.assertions(1);
@@ -70,11 +102,22 @@ describe('Validate input', () => {
         orgId,
         metaScopes
       })
-    ).rejects.toThrow();
+    ).rejects.toThrow('Required parameter(s) privateKey are missing');
   });
 });
 
 describe('Sign with invalid primary key', () => {
+  beforeEach(() => {
+    jwt.sign = jest.fn().mockImplementation((...args) => {
+      // call actual jwt module, not mocked version
+      return jwtActual.sign(...args)
+    })
+  })
+
+  afterEach(() => {
+    jwt.sign.mockClear()
+  })
+
   test('invalid primary key', () => {
     expect.assertions(1);
     return expect(
@@ -86,6 +129,62 @@ describe('Sign with invalid primary key', () => {
         metaScopes,
         privateKey
       })
-    ).rejects.toThrow();
+    ).rejects.toThrow('error:0906D06C:PEM routines:PEM_read_bio:no start line');
+  });
+});
+
+describe('Fetch jwt', () => {
+  beforeEach(() => {
+    jwt.sign = jest.fn().mockImplementation(() => {
+      return 'my_jwt_token'
+    })
+  })
+
+  afterEach(() => {
+    jwt.sign.mockClear()
+  })
+
+  test('valid jwt', () => {
+    fetch.mockImplementation(()=> mockResultSuccess)
+    return expect(
+      auth({
+        clientId,
+        clientSecret,
+        technicalAccountId,
+        orgId,
+        metaScopes,
+        privateKey
+      })
+    ).resolves.toEqual({"access_token": mockAccessToken, "expires_in": 123456});
+  });
+
+  test('invalid jwt, expected endpoint error', () => {
+    expect.assertions(1);
+    fetch.mockImplementation(()=> mockResultFailure)
+    return expect(
+      auth({
+        clientId,
+        clientSecret,
+        technicalAccountId,
+        orgId,
+        metaScopes,
+        privateKey
+      })
+    ).rejects.toThrow('my_error_code: This is the error description.');
+  });
+
+  test('invalid jwt, unknown error', () => {
+    expect.assertions(1);
+    fetch.mockImplementation(()=> mockResultFailureUnknown)    
+    return expect(
+      auth({
+        clientId,
+        clientSecret,
+        technicalAccountId,
+        orgId,
+        metaScopes,
+        privateKey
+      })
+    ).rejects.toThrow('An unknown error occurred while swapping jwt. The response is as follows: {\"foo\":\"bar\",\"baz\":\"faz\"}');
   });
 });


### PR DESCRIPTION
## Description

Unifies errors by using an Error object for all promise rejections.

## Related Issue

 See #9 

## Motivation and Context

For users of this lib, it will end up in cleaner code rather than trying to handle the various types of promise rejections.

## How Has This Been Tested?

Passes all `npm test` scenarios. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.