### PR TITLE
Add node-fetch custom agent support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,8 @@ governing permissions and limitations under the License.
 // Type definitions for @adobe/jwt-auth 0.3
 // Project: https://github.com/adobe/jwt-auth#readme
 
+import { Agent } from 'http'
+
 export = authorize;
 
 declare function authorize(
@@ -29,6 +31,7 @@ declare namespace authorize {
     passphrase?: string;
     metaScopes: string | string[];
     ims?: string;
+    agent?: Agent
   }
 
   export interface JWTAuthResponse {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ async function authorize(options) {
     privateKey,
     passphrase = '',
     metaScopes,
-    ims = 'https://ims-na1.adobelogin.com'
+    ims = 'https://ims-na1.adobelogin.com',
+    agent
   } = options;
 
   const errors = [];
@@ -101,7 +102,8 @@ async function authorize(options) {
   const postOptions = {
     method: 'POST',
     body: form,
-    headers: form.getHeaders()
+    headers: form.getHeaders(),
+    agent
   };
 
   return fetch(`${ims}/ims/exchange/jwt/`, postOptions)


### PR DESCRIPTION
Add node-fetch custom agent support

## Description

Adds a new `agent` property to the options object that
allows configuring the node fetch agent. This can be used
for adding proxy support, doing custom dns resolving and
other advanced use cases.

See https://nodejs.org/api/http.html#http_new_agent_options for
more information on http agents.

## Related Issue

https://github.com/adobe/jwt-auth/issues/50

## Motivation and Context

Will working on a project we had a problem that the back-end we deployed was only allowed network access through a proxy. For our own use of node-fetch this was easily fixed by using a configured https://www.npmjs.com/package/https-proxy-agent but this behaviour was not exposed through the APIs of @adobe/jwt-auth. Thus a simple fix, expose the node-fetch agent property in the API and pass the value through..

## How Has This Been Tested?

Tested with a custom proxy aware agent against mitmproxy & a proprietary company proxy. Test cases have not been changed, test coverage is still at 100%, but there is no real test that the agent is actually passed. Typescript types have been extended.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
