### PR TITLE
Error Codes - make error details more transparent to users of jwt-auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,26 +107,28 @@ async function authorize(options) {
   return fetch(`${ims}/ims/exchange/jwt/`, postOptions)
     .catch(e => throwRequestFailedError(e.message))
     .then(res => {
-      if (res.ok) {
-        return res.json();
-      } else {
-        throwRequestFailedError(res.statusText);
-      }
+      return res.json().then(data => {
+        return {
+          ok: res.ok,
+          json: data
+        };
+      });
     })
-    .then(json => {
+    .then(({ ok, json }) => {
       const { access_token, error, error_description } = json;
-      if (!access_token) {
-        if (error && error_description) {
-          const swapError = new Error(error_description);
-          swapError.code = error;
-          throw swapError;
-        } else {
-          throwUnexpectedResponseError(
-            `The response body is as follows: ${JSON.stringify(json)}`
-          );
-        }
+      if (ok && access_token) {
+        return json;
       }
-      return json;
+
+      if (error && error_description) {
+        const swapError = new Error(error_description);
+        swapError.code = error;
+        throw swapError;
+      } else {
+        throwUnexpectedResponseError(
+          `The response body is as follows: ${JSON.stringify(json)}`
+        );
+      }
     });
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When #52 was merged, it contains code that swallows helpful information from IMS for the thrown error. Bubble those details back up.

## Related Issue

#52, #11, #9

## Motivation and Context

Better messaging for users of jwt-auth for by the token exchange isn't working

## How Has This Been Tested?

`npm test`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
