### PR TITLE
fix link in readme for metascopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,14 @@ The config object is where you pass in all the required and optional parameters 
 | metaScopes         |                      | true     | Comma separated Sting or an Array |                                |
 | ims                |                      | false    | String                            | https://ims-na1.adobelogin.com |
 
-In order to determine which **metaScopes** you need to register for you can look them up by product in this [handy table](https://www.adobe.io/authentication/auth-methods.html#!AdobeDocs/adobeio-auth/master/JWT/Scopes.md).
+[metascopes]: https://developer.adobe.com/developer-console/docs/guides/authentication/JWT/Scopes/ "metascope table"
 
-For instance if you need to be authenticated to call API's for both GDPR and User Management you would [look them up](https://www.adobe.io/authentication/auth-methods.html#!AdobeDocs/adobeio-auth/master/JWT/Scopes.md) and find that they are:
+In order to determine which **metaScopes** you need to register for you can look them up by product in this [handy table][metascopes].
 
-- GDPR: https://ims-na1.adobelogin.com/s/ent_gdpr_sdk
-- User Management: https://ims-na1.adobelogin.com/s/ent_user_sdk
+For instance if you need to be authenticated to call API's for both GDPR and User Management you would [look them up][metascopes] and find that they are:
+
+- GDPR: `https://ims-na1.adobelogin.com/s/ent_gdpr_sdk`
+- User Management: `https://ims-na1.adobelogin.com/s/ent_user_sdk`
 
 They you would create an array of **metaScopes** as part of the config object. For instance:
 


### PR DESCRIPTION
## Description

Previous link to metascopes table just lands at the documentation root.  [`https://developer.adobe.com/developer-console/docs/guides/#!AdobeDocs/adobeio-auth/master/JWT/Scopes.md`](https://developer.adobe.com/developer-console/docs/guides/#!AdobeDocs/adobeio-auth/master/JWT/Scopes.md)

Should go directly to the relevant doc [`https://developer.adobe.com/developer-console/docs/guides/authentication/JWT/Scopes/`](https://developer.adobe.com/developer-console/docs/guides/authentication/JWT/Scopes/)

## Related Issue

N/A

## Motivation and Context

N/A

## How Has This Been Tested?

I followed the link.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] ~I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).~  Am employed by Adobe.
- [x] My code follows the code style of this project. (?)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] ~I have added tests to cover my changes.~ N/A
- [X] ~All new and existing tests passed.~ N/A
